### PR TITLE
Implement truly transparent pixels

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,9 +69,10 @@ USAGE:
     viu [FLAGS] [OPTIONS] <FILE>...
 
 FLAGS:
-    -m, --mirror     Display a mirror of the original image
-    -n, --name       Output the name of the file before displaying
-    -v, --verbose    Output what is going on
+    -m, --mirror        Display a mirror of the original image
+    -t, --transparent   Display transparent pixels in the color of the terminal
+    -n, --name          Output the name of the file before displaying
+    -v, --verbose       Output what is going on
 
 OPTIONS:
     -h, --height <height>    Resize the image to a provided height

--- a/src/app.rs
+++ b/src/app.rs
@@ -18,6 +18,7 @@ pub struct Config<'a> {
     name: bool,
     files: Vec<&'a str>,
     mirror: bool,
+    transparent: bool,
     width: Option<u32>,
     is_width_present: bool,
     height: Option<u32>,
@@ -49,6 +50,7 @@ impl<'a> Config<'a> {
             name: matches.is_present("name"),
             files,
             mirror: matches.is_present("mirror"),
+            transparent: matches.is_present("transparent"),
             width,
             is_width_present,
             height,
@@ -255,7 +257,7 @@ fn resize_and_print(conf: &Config, img: DynamicImage) -> (u32, u32) {
         print_img = print_img.fliph();
     }
 
-    printer::print(&print_img);
+    printer::print(&print_img, conf.transparent);
 
     let (print_width, print_height) = print_img.dimensions();
     let (width, height) = img.dimensions();

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,6 +37,12 @@ fn main() {
                 .help("Display a mirror of the original image"),
         )
         .arg(
+            Arg::with_name("transparent")
+                .short("t")
+                .long("transparent")
+                .help("Display transparent image with transparent background"),
+        )
+        .arg(
             Arg::with_name("width")
                 .short("w")
                 .long("width")

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -11,7 +11,6 @@ pub fn print(img: &DynamicImage) {
 
     let (width, _) = img.dimensions();
 
-    let mut curr_row_px = 0;
     let mut curr_col_px = 0;
     let mut buffer: Vec<ColorSpec> = Vec::with_capacity(width as usize);
     let mut mode: Status = Status::TopRow;
@@ -41,13 +40,11 @@ pub fn print(img: &DynamicImage) {
         if is_buffer_full(&buffer, width) {
             if mode == Status::TopRow {
                 mode = Status::BottomRow;
-                curr_row_px += 1;
                 curr_col_px = 0;
             }
             //only if the second row is completed flush the buffer and start again
             else if curr_col_px == width {
                 curr_col_px = 0;
-                curr_row_px += 1;
                 print_buffer(&mut buffer, false);
                 mode = Status::TopRow;
             }


### PR DESCRIPTION
This implements "truly" transparent pixels as described in #10, **while throwing away the old way** (the grid). I don't know if you want to keep it or not.

I'm using the color `Color::Magenta` as a placeholder for transparency, because the colorspec doesn't support it otherwise, and the rest of the code uses RGB colors exclusively. This shouldn't break displaying actually magenta pictures.

Code may or may not be terrible; I'm a Rust noob.