### PR TITLE
Add switch for not looping gifs

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ USAGE:
 FLAGS:
     -m, --mirror        Display a mirror of the original image
     -t, --transparent   Display transparent pixels in the color of the terminal
+    -1, --once          Loop only once through each given gif, then quit
     -n, --name          Output the name of the file before displaying
     -v, --verbose       Output what is going on
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -19,6 +19,7 @@ pub struct Config<'a> {
     files: Vec<&'a str>,
     mirror: bool,
     transparent: bool,
+    once: bool,
     width: Option<u32>,
     is_width_present: bool,
     height: Option<u32>,
@@ -51,6 +52,7 @@ impl<'a> Config<'a> {
             files,
             mirror: matches.is_present("mirror"),
             transparent: matches.is_present("transparent"),
+            once: matches.is_present("once"),
             width,
             is_width_present,
             height,
@@ -125,7 +127,7 @@ fn try_print_gif<R: Read>(
 ) -> Result<(), gif::DecodingError> {
     //only stop if there are other files to be previewed
     //so that if only the gif is viewed, it will loop infinitely
-    let should_loop = conf.files.len() <= 1;
+    let should_loop = (conf.files.len() <= 1) && !conf.once;
     let mut decoder = gif::Decoder::new(input_stream);
     decoder.set(gif::ColorOutput::RGBA);
     match decoder.read_info() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,6 +43,12 @@ fn main() {
                 .help("Display transparent image with transparent background"),
         )
         .arg(
+            Arg::with_name("once")
+                .short("1")
+                .long("once")
+                .help("Only loop once through the animation"),
+        )
+        .arg(
             Arg::with_name("width")
                 .short("w")
                 .long("width")


### PR DESCRIPTION
I don't know what you think about this feature, but since it was quick to do, here is my suggestion for a new switch: `--once`/`-1` disables the looping for animated GIFs. My usecase is showing animated commit images made with [lolcommits](https://github.com/lolcommits/lolcommits) in my terminal, after making a commit. Ctrl-C-ing after some time has passed is somewhat hard, this is easier.