### PR TITLE
Update Arch Linux package link

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ wapm install -g viu
 ### Packages
 
 #### Arch Linux
-There is an [AUR package available for Arch Linux](https://aur.archlinux.org/packages/viu/).
+Available in [`community/viu`](https://archlinux.org/packages/community/x86_64/viu/).
 
 #### NetBSD
 Available in [`graphics/viu`](http://cdn.netbsd.org/pub/pkgsrc/current/pkgsrc/graphics/viu/README.html).


### PR DESCRIPTION
Hey,
viu is now available in Arch Linux community repository. 
This PR basically updates the package link in README.md.