### PR TITLE
Added --blocks flag to force block output

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ USAGE:
     When FILE is -, read standard input.
 
 FLAGS:
+    -b, --blocks         Force block output
     -m, --mirror         Display a mirror of the original image
     -n, --name           Output the name of the file before displaying
     -1, --once           Only loop once through the animation

--- a/src/config.rs
+++ b/src/config.rs
@@ -37,11 +37,17 @@ impl<'a> Config<'a> {
 
         let transparent = matches.is_present("transparent");
 
+        let use_blocks = matches.is_present("blocks");
+
         let viuer_config = ViuerConfig {
             transparent,
             width,
             height,
             absolute_offset: false,
+            use_kitty: !use_blocks,
+            use_iterm: !use_blocks,
+            #[cfg(feature = "sixel")]
+            sixel: !use_blocks,
             ..Default::default()
         };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -78,6 +78,13 @@ fn main() {
                 .takes_value(true)
                 .help("Play gif at the given frame rate"),
         )
+        .arg(
+            Arg::with_name("blocks")
+                .short("b")
+                .long("blocks")
+                .takes_value(false)
+                .help("Force block output"),
+        )
         .get_matches();
 
     let conf = Config::new(&matches);


### PR DESCRIPTION
I hope I'm not out of bounds with this baby pull request. This just adds a --blocks/-b flag that forces the use of the `BlockPrinter`. This is helpful because the iTerm png viewer is quite slow, so when displaying a whole directory of images, it's sometimes useful to view them in block mode instead.