### PR TITLE
print an OSC8 hyperlink around the filename when -n is specified

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,6 +108,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
+name = "bytes"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -317,6 +323,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55ac459de2512911e4b674ce33cf20befaba382d05b62b008afc1c8b57cbf181"
 dependencies = [
  "spin",
+]
+
+[[package]]
+name = "gethostname"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0176e0459c2e4a1fe232f984bca6890e681076abb9934f6cea7c326f3fc47818"
+dependencies = [
+ "libc",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -704,9 +720,11 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 name = "viu"
 version = "1.5.0"
 dependencies = [
+ "bytes",
  "clap",
  "crossterm",
  "ctrlc",
+ "gethostname",
  "image",
  "viuer",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,8 @@ crossterm = "0.27"
 viuer = "0.7.1"
 ctrlc = { version = "3.4", features = ["termination"] }
 image = "0.24"
+gethostname = "0.4"
+bytes = "1.6"
 
 [features]
 default = []


### PR DESCRIPTION
This lets the user to open the file by clicking on or otherwise selecting the hyperlink in their terminal emulator.